### PR TITLE
Fix NSDateFormatter

### DIFF
--- a/Pod/Classes/JsonWriter.swift
+++ b/Pod/Classes/JsonWriter.swift
@@ -12,7 +12,7 @@ extension NSDate {
     var formattedISO8601: String {
         let formatter = NSDateFormatter()
         formatter.timeZone = NSTimeZone(forSecondsFromGMT: 0)
-        formatter.dateFormat = "yyyy-MM-dd'T'hh:mm:SSxxxxx"   //+00:00
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssxxxxx"   //+00:00
         return formatter.stringFromDate(self)
     }
 }


### PR DESCRIPTION
Fix exported timestamps so that they contain 24h clock, allowing for intraday use.